### PR TITLE
Add Terraform configurations for managing Cloudflare DNS records

### DIFF
--- a/.github/workflows/terraform-dns.yml
+++ b/.github/workflows/terraform-dns.yml
@@ -1,0 +1,35 @@
+name: 'terraform-dns'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    name: 'Terraform-cloudflare'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
+        with:
+          terraform_version: 1.6.5
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        run: terraform plan
+        env:
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve
+        env:
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# dns-as-code
-This repository contains the code to manage my own DNS records on CloudFlare
+# Terraform Cloudflare DNS Management
+
+This repository contains Terraform configurations for managing DNS records in Cloudflare.
+
+## Prerequisites
+
+- Terraform 0.14.0 or newer
+- Cloudflare account
+
+## Usage
+
+1. Clone the repository
+
+```bash
+git clone https://github.com/yourusername/dns-as-code.git
+cd dns-as-code
+```
+
+2. Initialize Terraform
+
+```bash
+terraform init
+```
+
+3. Plan the changes
+
+```bash
+terraform plan
+```
+
+4. Apply the changes
+
+```bash
+terraform apply
+```

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,13 @@
+// terraform code to configure cloudflare provider for dns
+provider "cloudflare" {
+  email   = "your-email@example.com"
+  api_key = "your-api-key"
+}
+
+resource "cloudflare_record" "example" {
+  domain = "example.com"
+  name   = "test"
+  value  = "192.0.2.1"
+  type   = "A"
+  ttl    = 3600
+}


### PR DESCRIPTION
This pull request adds Terraform configurations for managing DNS records in Cloudflare. The configurations include a Cloudflare provider block and a resource block for creating a DNS record. The Terraform code is versioned using Terraform 1.6.5. The pull request also includes a GitHub workflow for running Terraform commands on push to the main branch. The workflow sets up Terraform, initializes it, and then runs a plan and apply command. The Cloudflare email and API key are passed as environment variables to the Terraform commands using GitHub secrets. The README file has been updated with instructions on how to clone the repository, initialize Terraform, plan and apply the changes. The prerequisites for using the configurations are Terraform 0.14.0 or newer and a Cloudflare account.